### PR TITLE
Vend max

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
     - name: '🔨 Build'
       run: |
         gem install yard
-        readme_link=https://github.com/piotr-iohk/cardano-up/blob/${{ steps.versions.outputs.version }}/README.md
+        readme_link=https://github.com/piotr-iohk/vendi/blob/${{ steps.versions.outputs.version }}/README.md
         yard doc --title "Documentation for Vendi (${{ steps.versions.outputs.version }})"
         sed -i "s|<a href=\"index.html\" title=\"README\">|<a href=\"$readme_link\" title=\"README\">|" ./doc/_index.html
         cp ./doc/_index.html ./doc/index.html

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 Vendi is simple CNFT vending machine based on [`cardano-wallet`](https://github.com/input-output-hk/cardano-wallet).
 You need to have `cardano-wallet` started and synced.
 
-It... seems to work, check out the 
-  👉 **[Demo](http://185.201.114.10:4321)** 👈 and [how it was done](https://github.com/piotr-iohk/vendi/tree/master/demo#how-it-was-done).
+Check out the 
+  👉 **[Demo](http://185.201.114.10:4321)** 👈 and [how it was prepared](https://github.com/piotr-iohk/vendi/tree/master/demo#how-it-was-prepared).
 
 ## Installation
 

--- a/bin/vendi
+++ b/bin/vendi
@@ -8,8 +8,8 @@ doc = <<~DOCOPT
   Vendi - CNFT Vending Machine.
 
   Usage:
-    #{File.basename(__FILE__)} fill --collection <name> --price <lovelace> --nft-count <int> [--wallet-port <port>] [--skip-wallet-creation]
-    #{File.basename(__FILE__)} serve --collection <name> [--wallet-port <port>] [--logfile <file>]
+    #{File.basename(__FILE__)} fill --collection <name> --price <lovelace> --nft-count <int> [--wallet-port <port>] [--skip-wallet]
+    #{File.basename(__FILE__)} serve --collection <name> [--vend-max <int>] [--wallet-port <port>] [--logfile <file>]
     #{File.basename(__FILE__)} -v | --version
     #{File.basename(__FILE__)} -h | --help
 
@@ -19,9 +19,11 @@ doc = <<~DOCOPT
     serve                   Start vending machine.
     --collection <name>     Name of the collection.
     --price <lovelace>      Single NFT price in lovelace.
+    --vend-max <int>        Max number of NFTs vended in single transaction [default: 1].
     --nft-count <int>       How many NFTs would you like to generate.
     --wallet-port <port>    Cardano-wallet port [default: 8090].
     --logfile <file>        Logfile (will be rotated daily).
+    --skip-wallet           Skip creation of wallet when filling vending machine.
 
     -v --version            Check #{File.basename(__FILE__)} version.
     -h --help               This help.
@@ -47,7 +49,7 @@ begin
     price = o['--price']
     nft_count = o['--nft-count']
     wallet_port = o['--wallet-port']
-    skip_wallet = o['--skip-wallet-creation']
+    skip_wallet = o['--skip-wallet']
     vendi = Vendi.init({ port: wallet_port.to_i })
     begin
       if File.directory?(File.join(vendi.config_dir, collection_name))
@@ -72,13 +74,14 @@ begin
     collection_name = o['--collection']
     wallet_port = o['--wallet-port']
     logfile = o['--logfile']
+    vend_max = o['--vend-max']
     vendi = if logfile
               Vendi.init({ port: wallet_port.to_i }, :info, logfile)
             else
               Vendi.init({ port: wallet_port.to_i })
             end
     begin
-      vendi.serve(collection_name)
+      vendi.serve(collection_name, vend_max)
     rescue Errno::ECONNREFUSED => e
       # retry if cannot connect to cardano-wallet
       vendi.logger.error e.message

--- a/demo/README.md
+++ b/demo/README.md
@@ -2,32 +2,32 @@
 
 Vendi demo is available [HERE](http://185.201.114.10:4321).
 
-## How it was done
+## How it was prepared
 
-We have used [cardano-up](https://github.com/piotr-iohk/cardano-up) to spin up `cardano-node` and `cardano-wallet` on `preview` and `preprod` networks. That was easy!
+I have used [cardano-up](https://github.com/piotr-iohk/cardano-up) to spin up `cardano-node` and `cardano-wallet` on `preview` and `preprod` networks. That was easy!
 
 	$ cardano-up preview up --port 8090
 	$ cardano-up preprod up --port 8091
 
 Preview wallet works on port `8090`, preprod one on `8091`. Ok.
 
-We have filled Vendi with exemplary set of NFTs for both networks:
+I have filled Vendi with exemplary set of NFTs for both networks:
 
     $ vendi fill --collection TestBudzPreview --price 10000000 --nft-count 100 --wallet-port 8090
     $ vendi fill --collection TestBudzPreprod --price 10000000 --nft-count 100 --wallet-port 8091
 
-Vendi told us which address we need to fund for each vending machine and that's what we did. Thank you [Faucet](https://docs.cardano.org/cardano-testnet/tools/faucet)!
+Vendi told me which address I need to fund for each vending machine and that's what I did. Thank you [Faucet](https://docs.cardano.org/cardano-testnet/tools/faucet)!
 
-We waited few minutes until our wallets synced and started our vending machines:
+I waited few minutes until wallets synced and started vending machines:
 
-    $ vendi serve --collection TestBudzPreview --wallet-port 8090 --logfile preview.log
-    $ vendi serve --collection TestBudzPreprod --wallet-port 8091 --logfile preprod.log
+    $ vendi serve --collection TestBudzPreview --vend-max 5 --wallet-port 8090 --logfile preview.log
+    $ vendi serve --collection TestBudzPreprod --vend-max 5 --wallet-port 8091 --logfile preprod.log
 
-We wanted our logs to be available on our demo frontend. For that we used [frontail](https://github.com/mthenw/frontail). Very cool!
+I wanted the logs to be available on the demo frontend. For that I used [frontail](https://github.com/mthenw/frontail). Very cool!
 
     $ frontail -p 9001 preview.log
     $ frontail -p 9002 preprod.log
 
-Finally we have started our demo frontend from this folder! :tada:
+Finally I have started demo frontend from this folder! :tada:
 
-    $ HOST=<our_ip> ruby demo.rb
+    $ HOST=<my_ip> ruby demo.rb

--- a/demo/demo.rb
+++ b/demo/demo.rb
@@ -25,7 +25,7 @@ end
 
 get '/preview' do
   frontail_url = "http://#{ENV.fetch('HOST', nil)}:9001/"
-  price = @vendi.as_ada(@preview_config[:price])
+  price = @preview_config[:price]
   address = @preview_config[:wallet_address]
   policy_id = @preview_config[:wallet_policy_id]
   erb :demo, { locals: { frontail_url: frontail_url,
@@ -37,7 +37,7 @@ end
 
 get '/preprod' do
   frontail_url = "http://#{ENV.fetch('HOST', nil)}:9002/"
-  price = @vendi.as_ada(@preprod_config[:price])
+  price = @preprod_config[:price]
   address = @preprod_config[:wallet_address]
   policy_id = @preprod_config[:wallet_policy_id]
   erb :demo, { locals: { frontail_url: frontail_url,

--- a/demo/views/demo.erb
+++ b/demo/views/demo.erb
@@ -3,8 +3,16 @@
     <h3><%= network.capitalize %></h3>
   </center>
   <center>
-    Send <b><%= price %></b> to <b><%= address %></b> and get back NFT from Vendi!
+    Send <b><%= @vendi.as_ada(price) %></b> to <b><%= address %></b> and get NFT back from Vendi!
   </center>
+  <center>
+    Now you can get even up to <b>5</b> NFTs at once!
+  </center>
+  <% 1.upto 5 do |i|%>
+  <center>
+    Send <b><%= @vendi.as_ada(price * i) %></b> to get <b><%= i %></b>  NFT<%= 's' if i != 1 %> back. 
+  </center>
+  <% end %>
   <br/>
   <center>
     Policy id: <a target="_blank" href="https://<%= network %>.cexplorer.io/policy/<%= policy_id %>"><%= policy_id %></a>.

--- a/demo/views/layout.erb
+++ b/demo/views/layout.erb
@@ -73,7 +73,7 @@
     <nav id="sidebarMenu" class="col-md-3 col-lg-2 d-md-block bg-light sidebar collapse">
       <div class="position-sticky pt-3 sidebar-sticky">
         <h6 class="sidebar-heading d-flex justify-content-between align-items-center px-3 mt-4 mb-1 text-muted text-uppercase">
-          <span>Vendi Demo</span>
+          <span>Vendi Demo (v<%= Vendi::VERSION %>)</span>
         </h6>
         <ul class="nav flex-column">
           <li class="nav-item">

--- a/lib/vendi/machine.rb
+++ b/lib/vendi/machine.rb
@@ -174,7 +174,12 @@ module Vendi
         nfts = metadata_vending(collection_name)
         nfts_sent = metadata_sent(collection_name)
         wallet_balance = @cw.shelley.wallets.get(wid)['balance']['available']['quantity']
-        @logger.info "Vending machine [In stock: #{nfts.size}, Sent: #{nfts_sent.size}, NFT price: #{as_ada(price)}, Balance: #{as_ada(wallet_balance)}]"
+        @logger.info "[In stock: #{nfts.size}, Sent: #{nfts_sent.size}, NFT price: #{as_ada(price)}, Vend max: #{vend_max}, Balance: #{as_ada(wallet_balance)}]"
+        n = @cw.misc.network.information
+        unless n['sync_progress']['status'] == 'ready'
+          @logger.error "Network is not synced (#{n['sync_progress']['status']} #{n['sync_progress']['progress']['quantity']}%), waiting..."
+          sleep 5
+        end
 
         txs_new = get_incoming_txs(wid)
         if txs.size < txs_new.size

--- a/lib/vendi/machine.rb
+++ b/lib/vendi/machine.rb
@@ -88,7 +88,7 @@ module Vendi
       FileUtils.mkdir_p(collection_dir(collection_name))
       if skip_wallet
         @logger.info('Skipping wallet generation for your collection.')
-        wallet_details = if File.exists?(config_path(collection_name))
+        wallet_details = if File.exist?(config_path(collection_name))
                            c = config(collection_name)
                            c.delete(:price)
                            c
@@ -176,17 +176,7 @@ module Vendi
               @logger.info 'OK! VENDING!'
               @logger.info '----------------'
               dest_addr = get_dest_addr(t, address)
-
-              # prepare metadata and mint payload
-              keys = keys_to_mint(t['amount']['quantity'], price, vend_max, collection_name)
-              metadata = prepare_metadata(keys, collection_name, policy_id)
-              mint = mint_payload(keys, dest_addr)
-              @logger.debug JSON.pretty_generate(metadata)
-              @logger.debug JSON.pretty_generate(mint)
-
-              # mint
-              @logger.info "Minting #{keys.size} NFT(s): #{keys} to #{dest_addr}"
-              tx_res = construct_sign_submit(wid, pass, metadata, mint)
+              tx_res = mint_nft(collection_name, t['amount']['quantity'], vend_max, dest_addr)
               if outgoing_tx_ok?(tx_res)
                 mint_tx_id = tx_res.last['id']
                 wait_for_tx_in_ledger(wid, mint_tx_id)

--- a/lib/vendi/machine.rb
+++ b/lib/vendi/machine.rb
@@ -88,12 +88,18 @@ module Vendi
       FileUtils.mkdir_p(collection_dir(collection_name))
       if skip_wallet
         @logger.info('Skipping wallet generation for your collection.')
-        wallet_details = { wallet_id: '',
-                           wallet_name: '',
-                           wallet_pass: '',
-                           wallet_address: '',
-                           wallet_policy_id: '',
-                           wallet_mnemonics: '' }
+        wallet_details = if File.exists?(config_path(collection_name))
+                           c = config(collection_name)
+                           c.delete(:price)
+                           c
+                         else
+                           { wallet_id: '',
+                             wallet_name: '',
+                             wallet_pass: '',
+                             wallet_address: '',
+                             wallet_policy_id: '',
+                             wallet_mnemonics: '' }
+                         end
       else
         @logger.info('Generating wallet for your collection.')
         wallet_details = create_wallet("Vendi wallet - #{collection_name}")
@@ -110,6 +116,8 @@ module Vendi
       @logger.info("Generating exemplary CIP-25 metadata set into #{metadata_path(collection_name)}.")
       metadatas = generate_metadata(collection_name, nft_count.to_i)
       set_metadata(collection_name, metadatas)
+      set_metadata_vending(collection_name, metadatas)
+      set_metadata_sent(collection_name, {})
 
       @logger.info('IMPORTANT NOTES! 👇')
       @logger.info('----------------')
@@ -121,7 +129,7 @@ module Vendi
 
     # Turn on vending machine and make it serve NFTs for anyone who dares to
     # pay the 'price' to the 'address', that is specified in the config_file
-    def serve(collection_name)
+    def serve(collection_name, vend_max = 1)
       set_metadata_sent(collection_name, {}) unless File.exist?(metadata_sent_path(collection_name))
 
       c = config(collection_name)
@@ -138,8 +146,10 @@ module Vendi
 
       @logger.info 'Vending machine started.'
       @logger.info "Wallet id: #{wid}"
+      @logger.info "Policy id: #{policy_id}"
       @logger.info "Address: #{address}"
       @logger.info "NFT price: #{as_ada(price)}"
+      @logger.info "Vend max NFTs: #{vend_max}"
       @logger.info "Original NFT stock: #{metadata(collection_name).size}"
       @logger.info '----------------'
       unless File.exist?(metadata_vending_path(collection_name))
@@ -168,20 +178,20 @@ module Vendi
               dest_addr = get_dest_addr(t, address)
 
               # prepare metadata and mint payload
-              key = nfts.keys.sample
-              metadata = prepare_metadata(nfts, key, policy_id)
-              mint = mint_payload(asset_name(key.to_s), dest_addr)
+              keys = keys_to_mint(t['amount']['quantity'], price, vend_max, collection_name)
+              metadata = prepare_metadata(keys, collection_name, policy_id)
+              mint = mint_payload(keys, dest_addr)
               @logger.debug JSON.pretty_generate(metadata)
               @logger.debug JSON.pretty_generate(mint)
 
               # mint
-              @logger.info "Minting NFT: #{key} to #{dest_addr}"
+              @logger.info "Minting #{keys.size} NFT(s): #{keys} to #{dest_addr}"
               tx_res = construct_sign_submit(wid, pass, metadata, mint)
               if outgoing_tx_ok?(tx_res)
                 mint_tx_id = tx_res.last['id']
                 wait_for_tx_in_ledger(wid, mint_tx_id)
                 # update metadata files
-                update_metadata_files(nfts, key, metadata_vending_path(collection_name), metadata_sent_path(collection_name))
+                update_metadata_files(keys, collection_name)
               else
                 @logger.error 'Minting tx failed!'
                 @logger.error "Construct tx: #{JSON.pretty_generate(tx_res[0])}"

--- a/lib/vendi/minter.rb
+++ b/lib/vendi/minter.rb
@@ -104,7 +104,7 @@ module Vendi
       c = config(collection_name)
       wid = c[:wallet_id]
       pass = c[:wallet_pass]
-      policy_id = c[:policy_id]
+      policy_id = c[:wallet_policy_id]
       price = c[:price]
       keys = keys_to_mint(tx_amt, price, vend_max, collection_name)
       @logger.info "Minting #{keys.size} NFT(s): #{keys} to #{dest_address}"

--- a/lib/vendi/monitor.rb
+++ b/lib/vendi/monitor.rb
@@ -14,7 +14,9 @@ module Vendi
     # incoming tx is correct when the address is on any of the outputs (means that someone was sending to it)
     # and tx amount is >= price set in the config
     def incoming_tx_ok?(tx, address, price)
-      (tx['outputs'].any? { |o| (o['address'] == address) }) && (tx['amount']['quantity'] >= price)
+      (tx['outputs'].any? { |o| (o['address'] == address) }) &&
+        (tx['amount']['quantity'] >= price) &&
+        (tx['direction'] == 'incoming')
     end
 
     # trying to naively get address to send back NFT, take first address from the output that isn't our address

--- a/lib/vendi/utils.rb
+++ b/lib/vendi/utils.rb
@@ -44,11 +44,5 @@ module Vendi
         true
       end
     end
-
-    ##
-    # encode string asset_name to hex representation
-    def asset_name(asset_name)
-      asset_name.unpack1('H*')
-    end
   end
 end

--- a/lib/vendi/version.rb
+++ b/lib/vendi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Vendi
-  VERSION = '0.1.1'
+  VERSION = '0.2.0'
 end

--- a/spec/minter_spec.rb
+++ b/spec/minter_spec.rb
@@ -78,4 +78,15 @@ RSpec.describe Vendi::Minter do
     keys = @v.keys_to_mint(tx_amt, price, vend_max, coll)
     expect(keys.size).to eq 5
   end
+
+  it 'update_failed_mints' do
+    coll = 'TestBudzFailedMints'
+    price = 10_000_000
+    @v.fill(coll, price, 10, skip_wallet: true)
+
+    @v.update_failed_mints(coll, 'tx_id1', 'reason', 'keys')
+    expect(@v.failed_mints(coll).size).to eq 1
+    @v.update_failed_mints(coll, 'tx_id2', 'reason', 'keys')
+    expect(@v.failed_mints(coll).size).to eq 2
+  end
 end

--- a/spec/minter_spec.rb
+++ b/spec/minter_spec.rb
@@ -50,6 +50,32 @@ RSpec.describe Vendi::Minter do
     expect(metadata2.to_s).to include('TestBudz_7')
     expect(metadata2.to_s).to include('TestBudz_5')
     expect(metadata2.to_s).to include('policy_id')
+  end
 
+  it 'keys_to_mint' do
+    coll = 'TestBudzKeysToMint'
+    price = 10_000_000
+    vend_max = 5
+    @v.fill(coll, price, 10, skip_wallet: true)
+
+    tx_amt = 10_000_000
+    keys = @v.keys_to_mint(tx_amt, price, vend_max, coll)
+    expect(keys.size).to eq 1
+
+    tx_amt = 19_000_000
+    keys = @v.keys_to_mint(tx_amt, price, vend_max, coll)
+    expect(keys.size).to eq 1
+
+    tx_amt = 20_000_000
+    keys = @v.keys_to_mint(tx_amt, price, vend_max, coll)
+    expect(keys.size).to eq 2
+
+    tx_amt = 50_000_000
+    keys = @v.keys_to_mint(tx_amt, price, vend_max, coll)
+    expect(keys.size).to eq 5
+
+    tx_amt = 500_000_000
+    keys = @v.keys_to_mint(tx_amt, price, vend_max, coll)
+    expect(keys.size).to eq 5
   end
 end

--- a/spec/minter_spec.rb
+++ b/spec/minter_spec.rb
@@ -7,31 +7,49 @@ RSpec.describe Vendi::Minter do
 
   it 'update_metadata_files' do
     coll = 'TestBudz'
-    @v.fill(coll, 10_000_000, 100, skip_wallet: true)
-    expect(@v.metadata(coll).size).to eq 100
+    @v.fill(coll, 10_000_000, 5, skip_wallet: true)
+    expect(@v.metadata(coll).size).to eq 5
 
     @v.set_metadata_vending(coll, @v.metadata(coll))
     expect(@v.metadata(coll)).to eq @v.metadata_vending(coll)
 
-    @v.update_metadata_files(@v.metadata(coll), :TestBudz_44,
-                             @v.metadata_vending_path(coll),
-                             @v.metadata_sent_path(coll))
+    # only 1
+    @v.update_metadata_files([:TestBudz_3], coll)
 
-    expect(@v.metadata(coll).size).to eq 100
-    expect(@v.metadata_vending(coll).size).to eq 99
+    expect(@v.metadata(coll).size).to eq 5
+    expect(@v.metadata_vending(coll).size).to eq 4
     expect(@v.metadata_sent(coll).size).to eq 1
-    expect(@v.metadata_sent(coll)[:TestBudz_44]).not_to be_empty
+    expect(@v.metadata_sent(coll)[:TestBudz_3]).not_to be_empty
+
+    # more than 1
+    @v.update_metadata_files(%i[TestBudz_4 TestBudz_1 TestBudz_5], coll)
+
+    expect(@v.metadata(coll).size).to eq 5
+    expect(@v.metadata_vending(coll).size).to eq 1
+    expect(@v.metadata_sent(coll).size).to eq 4
+    expect(@v.metadata_sent(coll)[:TestBudz_4]).not_to be_empty
+    expect(@v.metadata_sent(coll)[:TestBudz_5]).not_to be_empty
+    expect(@v.metadata_sent(coll)[:TestBudz_3]).not_to be_empty
+    expect(@v.metadata_sent(coll)[:TestBudz_1]).not_to be_empty
   end
 
   it 'prepare_metadata' do
     coll = 'TestBudz44'
-    @v.fill(coll, 10_000_000, 1, skip_wallet: true)
-    nfts = @v.metadata(coll)
-    key = :TestBudz44_1
+    @v.fill(coll, 10_000_000, 10, skip_wallet: true)
 
-    metadata = @v.prepare_metadata(nfts, key, 'policy_id')
+    keys = [:TestBudz44_1]
+    metadata = @v.prepare_metadata(keys, coll, 'policy_id')
     expect(metadata).to have_key('721')
     expect(metadata.to_s).to include('TestBudz44_1')
     expect(metadata.to_s).to include('policy_id')
+
+    keys2 = %i[TestBudz_4 TestBudz_7 TestBudz_5]
+    metadata2 = @v.prepare_metadata(keys2, coll, 'policy_id')
+    expect(metadata2).to have_key('721')
+    expect(metadata2.to_s).to include('TestBudz_4')
+    expect(metadata2.to_s).to include('TestBudz_7')
+    expect(metadata2.to_s).to include('TestBudz_5')
+    expect(metadata2.to_s).to include('policy_id')
+
   end
 end


### PR DESCRIPTION
 - add `--vend-max` option in `serve` allowing to mint up to `--vend-max` nfts in single tx
 - add `failed-mints.json` that is updated in case something goes wrong (like insufficient funds sent or minting tx fails for some reason)
 - log error in case wallet goes out of sync